### PR TITLE
Improvements for rustc completer

### DIFF
--- a/ycmd/completers/go/hook.py
+++ b/ycmd/completers/go/hook.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2015  Google Inc.
+# Copyright (C) 2015 ycmd contributors
 #
-# This file is part of YouCompleteMe.
+# This file is part of ycmd.
 #
 # YouCompleteMe is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -38,5 +38,7 @@
   "csharp_server_port": 0,
   "hmac_secret": "",
   "server_keep_logfiles": 0,
-  "gocode_binary_path": ""
+  "gocode_binary_path": "",
+  "racerd_binary_path": "",
+  "rust_src_path": ""
 }


### PR DESCRIPTION
Hi. I just made some improvements to rustc_completer (But, I just saw @vheon's review in your PR Valloric/ycmd#268). I hope you can keep your focus on racerd (hopefully implement a cache) while I am working on this. And thanks for your amazing work, I can't wait for ycmd rust completion.

Changes are listed below:
- Add _FindRacerdBinary and _FindRustSrcPath methods to get racerd
  binary path and rust source path from user options.
- Raise errors in constructor, if anything goes wrong (racerd not
  available or rust source is not available) ycmd will stop trying.
- Start server on OnFileReadyToParse. racerd will only start if user
  is editing a rust file.
- Use utils.GetUnusedLocalhostPort() to get a random port and start
  racerd with this port.
- Use localhost and port from GetUnusedLocalhostPort for 'target'
  variable instead of parsing racerd message.
- Check phandle to determine ServerIsRunning.
- Fix blank lines before methods.
